### PR TITLE
feat: Retrieve Contentful data, along with rendering its rich text

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 - [x] Able to login with Firebase Auth [PR #1](https://github.com/johnkueh/nextjs-starter/pull/1)
 - [x] Able to check for auth on server-side via Firebase idToken [PR #2](https://github.com/johnkueh/nextjs-starter/pull/2)
 - [x] Able to load data from Firestore on server-side within `getStaticProps` [PR #3](https://github.com/johnkueh/nextjs-starter/pull/3)
+- [x] Able to load data from Contentful on server-side within `getStaticProps` [PR #4](https://github.com/johnkueh/nextjs-starter/pull/4)

--- a/components/ContentfulRichText.tsx
+++ b/components/ContentfulRichText.tsx
@@ -1,0 +1,24 @@
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { BLOCKS, Document, MARKS } from "@contentful/rich-text-types";
+import React from "react";
+
+const options = {
+  renderMark: {
+    [MARKS.BOLD]: (text) => <span className="bold">{text}</span>,
+  },
+  renderNode: {
+    [BLOCKS.HEADING_1]: (node, children) => <h1>{children}</h1>,
+    [BLOCKS.HEADING_2]: (node, children) => <h2>{children}</h2>,
+    [BLOCKS.HEADING_3]: (node, children) => <h3>{children}</h3>,
+    [BLOCKS.HEADING_4]: (node, children) => <h4>{children}</h4>,
+    [BLOCKS.HEADING_5]: (node, children) => <h5>{children}</h5>,
+    [BLOCKS.HEADING_6]: (node, children) => <h6>{children}</h6>,
+    [BLOCKS.PARAGRAPH]: (node, children) => <p>{children}</p>,
+  },
+};
+
+const ContentfulRichText = (props: { document: Document }) => {
+  return <>{documentToReactComponents(props.document, options)}</>;
+};
+
+export default ContentfulRichText;

--- a/lib/firebaseClient.ts
+++ b/lib/firebaseClient.ts
@@ -1,8 +1,7 @@
 import * as firebaseClient from "firebase/app";
 import "firebase/auth";
-import "firebase/firestore";
 
-if (!firebaseClient.apps.length) {
+if (typeof window !== "undefined" && !firebaseClient.apps.length) {
   const CLIENT_CONFIG = {
     apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
     authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,

--- a/lib/services/blogPost.ts
+++ b/lib/services/blogPost.ts
@@ -1,22 +1,20 @@
+import { Document } from "@contentful/rich-text-types";
+import { Entry } from "contentful";
+
 const client = require("contentful").createClient({
   space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
   accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
 });
 
-interface Entry {
-  sys: any;
-  fields: BlogPost;
-}
-
-interface BlogPost {
+export interface BlogPost {
   slug: string;
   title: string;
   summary: string;
-  content: any;
+  content: Document;
 }
 
 export async function getBlogPosts() {
-  const entries: { items: Entry[] } = await client.getEntries({
+  const entries: { items: Entry<BlogPost>[] } = await client.getEntries({
     content_type: "blogPost",
   });
   if (entries.items) return entries.items;
@@ -24,7 +22,7 @@ export async function getBlogPosts() {
 }
 
 export async function getBlogPost(slug: string | string[]) {
-  const entries: { items: Entry[] } = await client.getEntries({
+  const entries: { items: Entry<BlogPost>[] } = await client.getEntries({
     "fields.slug": slug,
     content_type: "blogPost",
   });

--- a/lib/services/blogPost.ts
+++ b/lib/services/blogPost.ts
@@ -1,0 +1,33 @@
+const client = require("contentful").createClient({
+  space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
+  accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
+});
+
+interface Entry {
+  sys: any;
+  fields: BlogPost;
+}
+
+interface BlogPost {
+  slug: string;
+  title: string;
+  summary: string;
+  content: any;
+}
+
+export async function getBlogPosts() {
+  const entries: { items: Entry[] } = await client.getEntries({
+    content_type: "blogPost",
+  });
+  if (entries.items) return entries.items;
+  console.log(`Error getting blogPosts`);
+}
+
+export async function getBlogPost(slug: string | string[]) {
+  const entries: { items: Entry[] } = await client.getEntries({
+    "fields.slug": slug,
+    content_type: "blogPost",
+  });
+  if (entries.items) return entries.items[0];
+  console.log(`Error getting blogPost: ${slug}`);
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@contentful/rich-text-html-renderer": "^14.1.1",
+    "@contentful/rich-text-react-renderer": "^14.1.1",
     "contentful": "^7.14.6",
     "firebase": "^7.21.0",
     "firebase-admin": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@contentful/rich-text-html-renderer": "^14.1.1",
+    "contentful": "^7.14.6",
     "firebase": "^7.21.0",
     "firebase-admin": "^9.2.0",
     "next": "9.5.3",

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,34 @@
+import { InferGetServerSidePropsType } from "next";
+import Link from "next/link";
+import React from "react";
+import { getBlogPosts } from "../lib/services/blogPost";
+
+const Blog = (props: InferGetServerSidePropsType<typeof getStaticProps>) => {
+  return (
+    <>
+      <h1>Blog</h1>
+      {props.blogPosts.map((blogPost) => (
+        <div key={blogPost.fields.slug}>
+          <h2>
+            <Link href={`/blog/${blogPost.fields.slug}`}>
+              {blogPost.fields.title}
+            </Link>
+          </h2>
+          <p>{blogPost.fields.summary}</p>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export async function getStaticProps(context) {
+  const blogPosts = await getBlogPosts();
+
+  return {
+    props: {
+      blogPosts,
+    },
+  };
+}
+
+export default Blog;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import React from "react";
+import ContentfulRichText from "../../components/ContentfulRichText";
 import { getBlogPost, getBlogPosts } from "../../lib/services/blogPost";
 
 const BlogPost = ({
@@ -12,6 +13,9 @@ const BlogPost = ({
         <a>Go back to blog</a>
       </Link>
       <h1>{blogPost.fields.title}</h1>
+      <div>
+        <ContentfulRichText document={blogPost.fields.content} />
+      </div>
     </>
   );
 };

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,0 +1,42 @@
+import { GetStaticPropsContext, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
+import React from "react";
+import { getBlogPost, getBlogPosts } from "../../lib/services/blogPost";
+
+const BlogPost = ({
+  blogPost,
+}: InferGetServerSidePropsType<typeof getStaticProps>) => {
+  return (
+    <>
+      <Link href="/blog">
+        <a>Go back to blog</a>
+      </Link>
+      <h1>{blogPost.fields.title}</h1>
+    </>
+  );
+};
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const blogPost = await getBlogPost(context.params.slug);
+
+  return {
+    props: {
+      blogPost,
+    },
+  };
+}
+
+// https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
+export async function getStaticPaths() {
+  const blogPosts = await getBlogPosts();
+  const paths = blogPosts.map((blogPost) => {
+    return { params: { slug: blogPost.fields.slug } };
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export default BlogPost;

--- a/pages/clients.tsx
+++ b/pages/clients.tsx
@@ -24,8 +24,6 @@ const Clients = (props: InferGetServerSidePropsType<typeof getStaticProps>) => {
   );
 };
 
-export default Clients;
-
 export async function getStaticProps(context) {
   const clients = await getClients();
 
@@ -35,3 +33,5 @@ export async function getStaticProps(context) {
     },
   };
 }
+
+export default Clients;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,6 +1014,19 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@contentful/rich-text-html-renderer@^14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-14.1.1.tgz#57c6c39cd42961238be8db2b936e4080da97b929"
+  integrity sha512-Sc9NDApq3S7AD1l5/s9ts6+AOCvjdpPGcFlAC55kZIViEI5Cw8TXuwVN303Aox3ixvlyC7FMeDJhx9EwT65jTw==
+  dependencies:
+    "@contentful/rich-text-types" "^14.1.1"
+    escape-html "^1.0.3"
+
+"@contentful/rich-text-types@^14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-14.1.1.tgz#2b105c8fdb36cd1f8ed06ce077a853f4ab5e3770"
+  integrity sha512-Iow9U3so7V+2AngYLmt42BGtHjHGl+DQpxvXaryJe1X9LPHrQ41pALztJZFzDgajoEswBjOgmI9CFeQ1oUAdJA==
+
 "@firebase/analytics-types@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.4.0.tgz#d6716f9fa36a6e340bc0ecfe68af325aa6f60508"
@@ -1804,6 +1817,13 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+axios@^0.19.1:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
@@ -2340,6 +2360,32 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+contentful-resolve-response@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.2.2.tgz#3f83a5f4742854de740e250a11020b4fb646da91"
+  integrity sha512-KyRz05f2YFJDSFs/L5jtsptbL5Fk3+ukSjRF94zFXq0FOtYoaxyCbqKgHhK2+3hlipxVQ+KGRus/tSaD6PoPMg==
+  dependencies:
+    lodash "^4.17.15"
+
+contentful-sdk-core@^6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-6.4.5.tgz#e73f4c5426f354608543fc73e46c17c6730180e9"
+  integrity sha512-rygNuiwbG6UKrJg6EDlaKewayTeLWrjA2wJwVmq7rV/DYo0cic6t28y0EMhRQ4pgJDV5HyUQFoFeBm2lwLfG2Q==
+  dependencies:
+    lodash "^4.17.10"
+    qs "^6.5.2"
+
+contentful@^7.14.6:
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.6.tgz#da692d68f361ceec14045c6114425579cddbfab9"
+  integrity sha512-7/Xqw/UT0/zW9DeVGAwtW4twGbThIc6rbLATrhUn7AXt/xTCFzgPiJxHgRU9gmr733q/Wckv663B51abDMS9Nw==
+  dependencies:
+    axios "^0.19.1"
+    contentful-resolve-response "^1.2.2"
+    contentful-sdk-core "^6.4.5"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.11"
+
 convert-source-map@1.7.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -2558,6 +2604,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
   dependencies:
     ms "2.1.2"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2877,6 +2930,11 @@ escalade@^3.0.1, escalade@^3.1.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
   integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -3108,6 +3166,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3764,6 +3829,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -3966,7 +4036,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.19:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4834,6 +4904,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.5.2:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 querystring-es3@^0.2.0:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,13 +1014,12 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@contentful/rich-text-html-renderer@^14.1.1":
+"@contentful/rich-text-react-renderer@^14.1.1":
   version "14.1.1"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-14.1.1.tgz#57c6c39cd42961238be8db2b936e4080da97b929"
-  integrity sha512-Sc9NDApq3S7AD1l5/s9ts6+AOCvjdpPGcFlAC55kZIViEI5Cw8TXuwVN303Aox3ixvlyC7FMeDJhx9EwT65jTw==
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-14.1.1.tgz#7a205c74c76bdf3ff7e6f315be2aadd3b8df8409"
+  integrity sha512-J9NhI3OeYt/ivj4uXj0874A1IhBADEcMSkyfNmU2XiKTwLfEab577+Tma5pe7mp/4NF4xGrq5YTU146vKufNHA==
   dependencies:
     "@contentful/rich-text-types" "^14.1.1"
-    escape-html "^1.0.3"
 
 "@contentful/rich-text-types@^14.1.1":
   version "14.1.1"
@@ -2929,11 +2928,6 @@ escalade@^3.0.1, escalade@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
   integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
-
-escape-html@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
- Fetch data from contentful and use both `getStaticProps` and `getStaticPaths` to render static pages via SSG.
- Use [@contentful/rich-text-react-renderer](https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer) for rendering rich text content

### Demos
![2020-09-20 15 42 58](https://user-images.githubusercontent.com/1704381/93695262-110d4e80-fb58-11ea-8fc4-faad096b723e.gif)
